### PR TITLE
a more correct implementation of LeftRightStore#limitOfRow

### DIFF
--- a/src/org/ojalgo/matrix/store/LeftRightStore.java
+++ b/src/org/ojalgo/matrix/store/LeftRightStore.java
@@ -77,7 +77,7 @@ final class LeftRightStore<N extends Number> extends ComposingStore<N> {
 
     @Override
     public int limitOfRow(final int row) {
-        return mySplit + myRight.limitOfRow(row);
+        return myRight.limitOfRow(row) == 0 ? this.getBase().limitOfRow(row) : mySplit + myRight.limitOfRow(row);
     }
 
     public void multiply(final Access1D<N> right, final ElementsConsumer<N> target) {


### PR DESCRIPTION
it takes into account a special case, when the right part is zero (for the current row), so the length depends on the left part, which may have lenght less than mySplit